### PR TITLE
Update requirements.txt with missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-python
 numpy
-tensorflow
+tensorflow==1.15
 keras
 scipy
-
+scikit-image


### PR DESCRIPTION
This is to help with the prepration to https://nsls2cfnusersmeeting.bnl.gov/workshops/workshop.aspx?year=2020&id=171.

Following [this example](https://xlearn.readthedocs.io/en/latest/source/ipynb/transform_train.html) from the documentation, I noticed a couple of issues with the `requirements.txt` file, in particular, `python` is not a pip-installable package. Also, there are imports of `scikit-image` somewhere, but the package is not listed here.

Most importantly, there is an API issue when using tensorflow v2:
```py
(UM2020) [vagrant@um2020 xlearn]$ ipython
Python 3.7.7 (default, Mar 26 2020, 15:48:22)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.14.0 -- An enhanced Interactive Python. Type '?' for help.
 
In [1]: import dxchange                                                                                          
 
In [2]: import matplotlib.pyplot as plt                                                                          
 
In [3]: from xlearn.transform import train
   ...: from xlearn.transform import model
   ...:                                                                                                           
Using TensorFlow backend.
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-3-8e75954f01f8> in <module>
----> 1 from xlearn.transform import train
      2 from xlearn.transform import model
 
~/UM2020/xlearn/xlearn/__init__.py in <module>
     53 from xlearn.transform import *
     54 from xlearn.utils import *
---> 55 from xlearn.models import *
     56 from xlearn.segmentation import *
     57
 
~/UM2020/xlearn/xlearn/models.py in <module>
     56 from tensorflow.python.keras.layers import Dense, Reshape, Flatten, \
     57     Dropout, Input, concatenate, Conv2D, MaxPooling2D, UpSampling2D, Conv2DTranspose, Activation
---> 58 from tensorflow.python.keras.utils import multi_gpu_model
     59
     60 # from keras.models import Sequential, Model
 
ImportError: cannot import name 'multi_gpu_model' from 'tensorflow.python.keras.utils' (/home/vagrant/mc/envs/UM2020/lib/python3.7/site-packages/tensorflow/python/keras/utils/__init__.py)
 
In [4]:                                                                                                           
```
https://www.tensorflow.org/api_docs/python/tf/keras/utils/multi_gpu_model says the function was deprecated on April 1st. A temporary workaround for the workshop is to down-pin the version of tensorflow to 1.15.